### PR TITLE
Updated JWT to use RwLock

### DIFF
--- a/examples/order.rs
+++ b/examples/order.rs
@@ -16,7 +16,7 @@ async fn main() {
     let symbol: String = "BTC-USD-PERP".into();
 
     let private_key = "<private key hex string>";
-    let mut client_private = Client::new(url, Some(private_key.into())).await.unwrap();
+    let client_private = Client::new(url, Some(private_key.into())).await.unwrap();
 
     info!(
         "Account Information {:?}",
@@ -90,6 +90,8 @@ async fn main() {
     info!("Order result {result:?}");
 
     tokio::time::sleep(Duration::from_secs(5)).await;
+
+    let _ = client_private.cancel_order(result.id).await.unwrap();
 
     for id in [orders_id, fills_id, position_id, account_id, balance_id] {
         manager.unsubscribe(id).await.unwrap();

--- a/examples/order.rs
+++ b/examples/order.rs
@@ -91,7 +91,7 @@ async fn main() {
 
     tokio::time::sleep(Duration::from_secs(5)).await;
 
-    let _ = client_private.cancel_order(result.id).await.unwrap();
+    client_private.cancel_order(result.id).await.unwrap();
 
     for id in [orders_id, fills_id, position_id, account_id, balance_id] {
         manager.unsubscribe(id).await.unwrap();

--- a/examples/rest.rs
+++ b/examples/rest.rs
@@ -14,7 +14,7 @@ async fn main() {
     info!("markets_static {:?}", client.markets().await);
 
     let private_key = "<private key hex string>";
-    let mut client_private = Client::new(url, Some(private_key.into())).await.unwrap();
+    let client_private = Client::new(url, Some(private_key.into())).await.unwrap();
 
     info!("JWT {:?}", client_private.jwt().await);
 }

--- a/src/rest.rs
+++ b/src/rest.rs
@@ -154,7 +154,7 @@ impl Client {
         let (ts, _jwt) = &*lock;
         SystemTime::now()
             .duration_since(*ts)
-            .map_or(false, |duration| duration.as_secs() > JWT_UPDATE_INTERVAL)
+            .map_or(true, |duration| duration.as_secs() > JWT_UPDATE_INTERVAL)
     }
 
     /// Refresh the current JWT token

--- a/src/rest.rs
+++ b/src/rest.rs
@@ -1,4 +1,5 @@
 use std::str::FromStr;
+use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use log::trace;
@@ -6,6 +7,7 @@ use reqwest::header::{HeaderMap, HeaderValue};
 use starknet_core::types::Felt;
 use starknet_core::utils::cairo_short_string_to_felt;
 use starknet_signers::SigningKey;
+use tokio::sync::RwLock;
 
 use crate::error::{Error, Result};
 use crate::message::{account_address, auth_headers, sign_order};
@@ -14,6 +16,8 @@ use crate::structs::{
     Positions, ResultsContainer, SystemConfig, BBO,
 };
 use crate::url::URL;
+
+const JWT_UPDATE_INTERVAL: u64 = 240;
 
 enum Method {
     Get,
@@ -25,16 +29,30 @@ pub struct Client {
     url: URL,
     client: reqwest::Client,
     l2_chain_private_key_account: Option<(Felt, SigningKey, Felt)>,
-    jwt: Option<(SystemTime, String)>, // the current valid JWT and timestamp created
+    jwt: Arc<RwLock<(SystemTime, String)>>, // the current valid JWT and timestamp created
 }
 
 impl Client {
+    /// Create a new Client instance
+    ///
+    /// # Parameters
+    ///
+    /// * `url` - A URL struct representing the base URL for the REST API
+    /// * `l2_private_key_hex_str` - An optional string representing the private key for the L2 chain
+    ///
+    /// # Returns
+    ///
+    /// A Result with the new Client instance
+    ///
+    /// # Errors
+    ///
+    /// If the client cannot be created
     pub async fn new(url: URL, l2_private_key_hex_str: Option<String>) -> Result<Self> {
         let mut new_client = Self {
             url,
             client: reqwest::Client::new(),
             l2_chain_private_key_account: None,
-            jwt: None,
+            jwt: Arc::new(RwLock::new((UNIX_EPOCH, "".to_string()))),
         };
         if let Some(hex_str) = l2_private_key_hex_str {
             let signing_key = SigningKey::from_secret_scalar(
@@ -61,16 +79,29 @@ impl Client {
         Ok(new_client)
     }
 
+    /// Get the Paradex system configuration
+    ///
+    /// # Returns
+    ///
+    /// A SystemConfig struct representing the system configuration
+    ///
+    /// # Errors
+    ///
+    /// If the system configuration cannot be retrieved
     pub async fn system_config(&self) -> Result<SystemConfig> {
-        self.request(
-            Method::Get,
-            "/v1/system/config".into(),
-            None::<()>,
-            None,
-        )
-        .await
+        self.request(Method::Get, "/v1/system/config".into(), None::<()>, None)
+            .await
     }
 
+    /// Get the list of markets on the exchange
+    ///
+    /// # Returns
+    ///
+    /// A vector of MarketSummaryStatic structs representing the markets
+    ///
+    /// # Errors
+    ///
+    /// If the markets cannot be retrieved
     pub async fn markets(&self) -> Result<Vec<MarketSummaryStatic>> {
         self.request(Method::Get, "/v1/markets".into(), None::<()>, None)
             .await
@@ -81,17 +112,75 @@ impl Client {
             )
     }
 
+    /// Check if the client has a private key set allowing for private API calls
+    ///
+    /// # Returns
+    ///
+    /// A boolean indicating if the client has a private key set
     pub(crate) fn is_private(&self) -> bool {
         self.l2_chain_private_key_account.is_some()
     }
 
-    pub async fn jwt(&mut self) -> Result<String> {
-        if self.jwt.as_ref().is_none_or(|(ts, _jwt)| {
+    /// Get the current JWT token
+    /// If the token is expired, it will be refreshed
+    ///
+    /// # Returns
+    ///
+    /// A string representing the current JWT token
+    ///
+    /// # Errors
+    ///
+    /// If the token cannot be refreshed
+    pub async fn jwt(&self) -> Result<String> {
+        // Check if Invalid
+        if self.check_jwt_expired().await {
+            self.refresh_jwt(false).await?;
+        }
+
+        // Return JWT
+        let lock = self.jwt.read().await;
+        let (_ts, jwt) = &*lock;
+        Ok(jwt.clone())
+    }
+
+    /// Check if the current JWT token is expired
+    ///
+    /// # Returns
+    ///
+    /// A boolean indicating if the token is expired
+    async fn check_jwt_expired(&self) -> bool {
+        // Read Lock to check if JWT is valid
+        let lock = self.jwt.read().await;
+        let (ts, _jwt) = &*lock;
+        SystemTime::now()
+            .duration_since(*ts)
+            .map_or(false, |duration| duration.as_secs() > JWT_UPDATE_INTERVAL)
+    }
+
+    /// Refresh the current JWT token
+    /// Allows for a force update to bypass the check for expired token
+    ///
+    /// # Parameters
+    ///
+    /// * `force_update` - A boolean indicating if the token should be updated regardless of expiration
+    ///
+    /// # Errors
+    ///
+    /// If the token cannot be refreshed
+    pub async fn refresh_jwt(&self, force_update: bool) -> Result<()> {
+        // Write Lock to update JWT
+        let mut lock = self.jwt.write().await;
+
+        // Recheck if JWT is expired after acquiring write lock to prevent multiple updates at once with async calls
+        let is_jwt_expired = {
+            let (ts, _jwt) = &*lock;
             SystemTime::now()
                 .duration_since(*ts)
-                .ok()
-                .is_none_or(|duration| duration.as_secs() > 240)
-        }) {
+                .map_or(true, |duration| duration.as_secs() > JWT_UPDATE_INTERVAL)
+        };
+
+        // Update JWT if expired or forced update is requested
+        if is_jwt_expired || force_update {
             let (l2_chain, signing_key, account) = self
                 .l2_chain_private_key_account
                 .as_ref()
@@ -107,15 +196,24 @@ impl Client {
                 )
                 .await
                 .map(|s| s.jwt_token)?;
-            self.jwt = Some((timestamp, token));
+            *lock = (timestamp, token);
         }
-        if let Some((_ts, jwt)) = &self.jwt {
-            Ok(jwt.clone())
-        } else {
-            panic!("unexpected path")
-        }
+        Ok(())
     }
 
+    /// Get the current BBO for a market
+    ///
+    /// # Parameters
+    ///
+    /// * `market_symbol` - A string representing the market symbol
+    ///
+    /// # Returns
+    ///
+    /// A BBO struct representing the best bid and offer for the market
+    ///
+    /// # Errors
+    ///
+    /// If the BBO cannot be retrieved
     pub async fn bbo(&self, market_symbol: String) -> Result<BBO> {
         self.request(
             Method::Get,
@@ -126,7 +224,20 @@ impl Client {
         .await
     }
 
-    pub async fn create_order(&mut self, order_request: OrderRequest) -> Result<OrderUpdate> {
+    /// Create an order on the exchange
+    ///
+    /// # Parameters
+    ///
+    /// * `order_request` - An OrderRequest struct representing the order to be created
+    ///
+    /// # Returns
+    ///
+    /// An OrderUpdate struct representing the order that was created
+    ///
+    /// # Errors
+    ///
+    /// If the order cannot be created
+    pub async fn create_order(&self, order_request: OrderRequest) -> Result<OrderUpdate> {
         let timestamp = SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .map_err(|e| Error::TimeError(e.to_string()))?
@@ -143,7 +254,20 @@ impl Client {
             .await
     }
 
-    pub async fn cancel_order(&mut self, order_id: String) -> Result<()> {
+    /// Cancel an order on the exchange by order ID
+    ///
+    /// # Parameters
+    ///
+    /// * `order_id` - A string representing the order ID to be cancelled
+    ///
+    /// # Returns
+    ///
+    /// A Result indicating success or failure
+    ///
+    /// # Errors
+    ///
+    /// If the order cannot be cancelled
+    pub async fn cancel_order(&self, order_id: String) -> Result<()> {
         match self
             .request_auth::<(), ()>(Method::Delete, format!("/v1/orders/{order_id}"), None::<()>)
             .await
@@ -154,7 +278,20 @@ impl Client {
         }
     }
 
-    pub async fn cancel_order_by_client_id(&mut self, client_order_id: String) -> Result<()> {
+    /// Cancel an order on the exchange by client ID
+    ///
+    /// # Parameters
+    ///
+    /// * `client_order_id` - A string representing the client order ID to be cancelled
+    ///
+    /// # Returns
+    ///
+    /// A Result indicating success or failure
+    ///
+    /// # Errors
+    ///
+    /// If the order cannot be cancelled
+    pub async fn cancel_order_by_client_id(&self, client_order_id: String) -> Result<()> {
         match self
             .request_auth::<(), ()>(
                 Method::Delete,
@@ -169,12 +306,34 @@ impl Client {
         }
     }
 
-    pub async fn cancel_all_orders(&mut self) -> Result<Vec<String>> {
+    /// Cancel all orders on the exchange
+    ///
+    /// # Returns
+    ///
+    /// A vector of strings representing the order IDs that were cancelled
+    ///
+    /// # Errors
+    ///
+    /// If the orders cannot be cancelled
+    pub async fn cancel_all_orders(&self) -> Result<Vec<String>> {
         self.request_auth(Method::Delete, "/v1/orders".into(), None::<()>)
             .await
     }
 
-    pub async fn cancel_all_orders_for_market(&mut self, market: String) -> Result<Vec<String>> {
+    /// Cancel all orders on the exchange for a specific market
+    ///
+    /// # Parameters
+    ///
+    /// * `market` - A string representing the market symbol to cancel orders for
+    ///
+    /// # Returns
+    ///
+    /// A vector of strings representing the order IDs that were cancelled
+    ///
+    /// # Errors
+    ///
+    /// If the orders cannot be cancelled
+    pub async fn cancel_all_orders_for_market(&self, market: String) -> Result<Vec<String>> {
         self.request_auth(
             Method::Delete,
             format!("/v1/orders/?market={market}"),
@@ -183,23 +342,65 @@ impl Client {
         .await
     }
 
-    pub async fn account_information(&mut self) -> Result<AccountInformation> {
+    /// Get the Account Information
+    ///
+    /// # Returns
+    ///
+    /// An AccountInformation struct representing the account information
+    ///
+    /// # Errors
+    ///
+    /// If the account information cannot be retrieved
+    pub async fn account_information(&self) -> Result<AccountInformation> {
         self.request_auth(Method::Get, "/v1/account".into(), None::<()>)
             .await
     }
 
-    pub async fn balance(&mut self) -> Result<Balances> {
+    /// Get the balances for the account
+    ///
+    /// # Returns
+    ///
+    /// A Balances struct representing the account balances
+    ///
+    /// # Errors
+    ///
+    /// If the balances cannot be retrieved
+    pub async fn balance(&self) -> Result<Balances> {
         self.request_auth(Method::Get, "/v1/balance".into(), None::<()>)
             .await
     }
 
-    pub async fn positions(&mut self) -> Result<Positions> {
+    /// Get the positions for the account
+    ///
+    /// # Returns
+    ///
+    /// A Positions struct representing the account positions
+    ///
+    /// # Errors
+    ///
+    /// If the positions cannot be retrieved
+    pub async fn positions(&self) -> Result<Positions> {
         self.request_auth(Method::Get, "/v1/positions".into(), None::<()>)
             .await
     }
 
+    /// Perform a REST API request with authentication headers
+    ///
+    /// # Parameters
+    ///
+    /// * `method` - A Method enum representing the HTTP method to use
+    /// * `path` - A string representing the path to the API endpoint
+    /// * `body` - An optional serializable object representing the request body
+    ///
+    /// # Returns
+    ///
+    /// A Result with the deserialized response object
+    ///
+    /// # Errors
+    ///
+    /// If the request cannot be completed
     async fn request_auth<B: serde::Serialize, T: for<'de> serde::Deserialize<'de>>(
-        &mut self,
+        &self,
         method: Method,
         path: String,
         body: Option<B>,
@@ -210,6 +411,22 @@ impl Client {
         self.request(method, path, body, Some(header_map)).await
     }
 
+    /// Perform a REST API request with optional additional headers
+    ///
+    /// # Parameters
+    ///
+    /// * `method` - A Method enum representing the HTTP method to use
+    /// * `path` - A string representing the path to the API endpoint
+    /// * `body` - An optional serializable object representing the request body
+    /// * `additional_headers` - An optional HeaderMap representing additional headers to include
+    ///
+    /// # Returns
+    ///
+    /// A Result with the deserialized response object
+    ///
+    /// # Errors
+    ///
+    /// If the request cannot be completed
     async fn request<B: serde::Serialize, T: for<'de> serde::Deserialize<'de>>(
         &self,
         method: Method,


### PR DESCRIPTION
Made Async API calls easier

Updated JWT to be held by a RwLock - allowing auth functions to use a standard self reference instead of a mutable reference. This allows holding the Rest Client in a RwLock in Read mode to allow multiple async calls to occur at the same time.

Update functionality also ensures that multiple async calls don't compete to update the JWT by rechecking if expired while holding write lock. Added ability for updating JWT externally to calling an auth function to allow users to manage this externally if wanted.

Tested in prod and appears to be a lot faster at placing/cancelling multiple orders at once. Also removed option around JWT as we can set the expiry time to Epoch and it will automatically be generated first auth call.

Added a little documentation