### PR TITLE
Make delta1 optional in structs.rs

### DIFF
--- a/examples/rest_market_info.rs
+++ b/examples/rest_market_info.rs
@@ -1,0 +1,14 @@
+use log::info;
+
+#[tokio::main]
+async fn main() {
+    // Initialize logging
+    simple_logger::init_with_level(log::Level::Info).unwrap();
+
+    // Create a new client connected to testnet
+    let client = paradex::rest::Client::new(paradex::url::URL::Testnet, None).await.unwrap();
+
+    // Get and print all available markets
+    let markets = client.markets().await.unwrap();
+    info!("Markets: {:#?}", markets);
+} 

--- a/src/structs.rs
+++ b/src/structs.rs
@@ -204,7 +204,8 @@ pub struct MarketSummaryStatic {
         deserialize_with = "deserialize_string_to_f64"
     )]
     pub clamp_rate: f64,
-    pub delta1_cross_margin_params: Delta1CrossMarginParams,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub delta1_cross_margin_params: Option<Delta1CrossMarginParams>,
     pub expiry_at: i64,
     pub funding_period_hours: u16,
     #[serde(


### PR DESCRIPTION
Seems that market info doesn't return delta1_cross_maring_params for options.
I'm not sure if this is the best approach but seems making this optional in structs fixes it.

Without the change the below endpoint crashes on desarializing:
```rust
    pub async fn markets(&self) -> Result<Vec<MarketSummaryStatic>> {
        self.request(Method::Get::<()>(vec![]), "/v1/markets".into(), None)
            .await
            .map(
                |result_container: ResultsContainer<Vec<MarketSummaryStatic>>| {
                    result_container.results
                },
            )
    }
```
New output:

```rust
 MarketSummaryStatic {
        asset_kind: "PERP_OPTION",
        base_currency: "BTC",
        clamp_rate: 0.0,
        delta1_cross_margin_params: None,
        expiry_at: 0,
        funding_period_hours: 24,
        interest_rate: 0.0,
        iv_bands_width: Some(
            0.3,
        ),
        market_kind: "cross",
        max_funding_rate: 0.0,
        max_funding_rate_change: 0.0,
        max_open_orders: 150,
        max_order_size: 100.0,
        max_tob_spread: 0.3,
        min_notional: 100.0,
        option_type: Some(
            PUT,
        ),
        oracle_ewma_factor: 0.20000046249626113,
        order_size_increment: 0.001,
        position_limit: 30.0,
        price_bands_width: 0.3,
        price_feed_id: "",
        price_tick_size: 0.1,
        quote_currency: "USD",
        settlement_currency: "USDC",
        strike_price: Some(
            101000.0,
        ),
        symbol: "BTC-USD-101000-P",
        tags: [],
  ```