### PR TITLE
chore: update pragma registry from devnet to production

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[registries.pragma]
+index = "sparse+https://registry.devnet.pragma.build/api/v1/crates/"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "paradex"
-version = "0.4.9"
+version = "0.5.0"
 edition = "2024"
 license = "MIT"
 description = "Paradex client library"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "paradex"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2024"
 license = "MIT"
 description = "Paradex client library"
@@ -17,7 +17,7 @@ reqwest =  {version="0.12.15", features=["json"]}
 rust_decimal = {version="1.37.1", features=["serde"]}
 serde = "1.0.219"
 serde_json = "1.0.140"
-starknet-core = "0.13.0"
+starknet-core = "0.14.0"
 starknet-crypto = "0.7.4"
 starknet-signers = "0.11.0"
 thiserror = "2.0.12"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "paradex"
-version = "0.5.1"
+version = "0.5.2"
 edition = "2024"
 license = "MIT"
 description = "Paradex client library"
-repository  = "https://github.com/snow-avocado/paradex-rs"
+repository = "https://github.com/snow-avocado/paradex-rs"
 
 [dependencies]
 cached = "0.55.1"
@@ -13,16 +13,15 @@ futures-util = "0.3.31"
 jsonrpsee-core = "0.24.9"
 jsonrpsee-types = "0.24.9"
 log = "0.4.27"
-reqwest =  {version="0.12.15", features=["json"]}
-rust_decimal = {version="1.37.1", features=["serde"]}
+reqwest = { version = "0.12.15", features = ["json"] }
+rust_decimal = { version = "1.37.1", features = ["serde"] }
 serde = "1.0.219"
 serde_json = "1.0.140"
-starknet-core = "0.14.0"
+starknet = "0.14.0"
 starknet-crypto = "0.7.4"
-starknet-signers = "0.11.0"
 thiserror = "2.0.12"
-tokio = { version = "1.44.2", features=["full"]}
-tokio-tungstenite = {version = "0.26.2", features=["native-tls"]}
+tokio = { version = "1.44.2", features = ["full"] }
+tokio-tungstenite = { version = "0.26.2", features = ["native-tls"] }
 
 [dev-dependencies]
 simple_logger = "5.0.0"

--- a/benches/order_sign.rs
+++ b/benches/order_sign.rs
@@ -4,8 +4,8 @@ use paradex::{
     structs::{OrderRequest, OrderType, Side},
 };
 use rust_decimal::{Decimal, prelude::FromPrimitive};
+use starknet::signers::SigningKey;
 use starknet_crypto::Felt;
-use starknet_signers::SigningKey;
 
 use mimalloc::MiMalloc;
 

--- a/benches/order_sign.rs
+++ b/benches/order_sign.rs
@@ -1,9 +1,9 @@
-use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
+use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
 use paradex::{
     message::sign_order,
     structs::{OrderRequest, OrderType, Side},
 };
-use rust_decimal::{prelude::FromPrimitive, Decimal};
+use rust_decimal::{Decimal, prelude::FromPrimitive};
 use starknet_crypto::Felt;
 use starknet_signers::SigningKey;
 

--- a/examples/order.rs
+++ b/examples/order.rs
@@ -6,7 +6,7 @@ use paradex::{
     structs::{ModifyOrderRequest, OrderRequest, OrderType, Side},
     url::URL,
 };
-use rust_decimal::{prelude::FromPrimitive, Decimal};
+use rust_decimal::{Decimal, prelude::FromPrimitive};
 
 #[tokio::main]
 async fn main() {
@@ -70,12 +70,14 @@ async fn main() {
         .await
         .unwrap();
     let funding_payments_id = manager
-    .subscribe(
-        paradex::ws::Channel::FundingPayments { market_symbol: None },
-        Box::new(|message| info!("Received funding payment {message:?}")),
-    )
-    .await
-    .unwrap();
+        .subscribe(
+            paradex::ws::Channel::FundingPayments {
+                market_symbol: None,
+            },
+            Box::new(|message| info!("Received funding payment {message:?}")),
+        )
+        .await
+        .unwrap();
 
     tokio::time::sleep(Duration::from_secs(2)).await;
 
@@ -112,9 +114,19 @@ async fn main() {
 
     tokio::time::sleep(Duration::from_secs(5)).await;
 
-    info!("Cancel Order Result {:?}", client_private.cancel_order(result.id.clone()).await);
+    info!(
+        "Cancel Order Result {:?}",
+        client_private.cancel_order(result.id.clone()).await
+    );
 
-    for id in [orders_id, fills_id, position_id, account_id, balance_id, funding_payments_id] {
+    for id in [
+        orders_id,
+        fills_id,
+        position_id,
+        account_id,
+        balance_id,
+        funding_payments_id,
+    ] {
         manager.unsubscribe(id).await.unwrap();
     }
 

--- a/examples/rest.rs
+++ b/examples/rest.rs
@@ -18,7 +18,30 @@ async fn main() {
 
     info!("JWT {:?}", client_private.jwt().await);
     info!("Open Orders {:?}", client_private.open_orders().await);
-    info!("Fills {:?}", client_private.fills(Some("BTC-USD-PERP".to_string()), Some(chrono::Utc::now() - chrono::Duration::days(2)), Some(chrono::Utc::now())).await.unwrap().len());
-    info!("Funding {:?}", client_private.funding_payments(None, None, None).await.unwrap());
-    info!("Margin Config for BTC-USD-PERP {:?}", client_private.account_margin_configuration("BTC-USD-PERP".to_string()).await.unwrap());
+    info!(
+        "Fills {:?}",
+        client_private
+            .fills(
+                Some("BTC-USD-PERP".to_string()),
+                Some(chrono::Utc::now() - chrono::Duration::days(2)),
+                Some(chrono::Utc::now())
+            )
+            .await
+            .unwrap()
+            .len()
+    );
+    info!(
+        "Funding {:?}",
+        client_private
+            .funding_payments(None, None, None)
+            .await
+            .unwrap()
+    );
+    info!(
+        "Margin Config for BTC-USD-PERP {:?}",
+        client_private
+            .account_margin_configuration("BTC-USD-PERP".to_string())
+            .await
+            .unwrap()
+    );
 }

--- a/examples/rest.rs
+++ b/examples/rest.rs
@@ -11,7 +11,7 @@ async fn main() {
     let client = Client::new(url, None).await.unwrap();
     info!("system_config {:?}", client.system_config().await);
     info!("BBO {:?}", client.bbo(symbol).await);
-    info!("markets_static {:?}", client.markets().await);
+    info!("markets_static {:?}", client.markets(None).await);
 
     let private_key = std::env::var("PRIVATE_KEY").expect("PRIVATE_KEY not set");
     let client_private = Client::new(url, Some(private_key)).await.unwrap();

--- a/examples/rest_market_info.rs
+++ b/examples/rest_market_info.rs
@@ -6,9 +6,11 @@ async fn main() {
     simple_logger::init_with_level(log::Level::Info).unwrap();
 
     // Create a new client connected to testnet
-    let client = paradex::rest::Client::new(paradex::url::URL::Testnet, None).await.unwrap();
+    let client = paradex::rest::Client::new(paradex::url::URL::Testnet, None)
+        .await
+        .unwrap();
 
     // Get and print all available markets
     let markets = client.markets().await.unwrap();
     info!("Markets: {:#?}", markets);
-} 
+}

--- a/examples/rest_market_info.rs
+++ b/examples/rest_market_info.rs
@@ -11,6 +11,9 @@ async fn main() {
         .unwrap();
 
     // Get and print all available markets
-    let markets = client.markets().await.unwrap();
+    let markets = client.markets(None).await.unwrap();
     info!("Markets: {:#?}", markets);
+
+    let market_for_btc = client.markets(Some("BTC".to_string())).await.unwrap();
+    info!("Markets BTC: {:#?}", market_for_btc);
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -22,9 +22,13 @@ pub enum Error {
     #[error("Missing Private Key")]
     MissingPrivateKey,
     #[error("Paradex Error: status_code={status_code:?} error={error:?}, message={message:?}")]
-    ParadexError { status_code : StatusCode, error: Option<String>, message: String },
+    ParadexError {
+        status_code: StatusCode,
+        error: Option<String>,
+        message: String,
+    },
     #[error("HTTP Error: status_code={status_code:?}")]
-    HTTPError { status_code: StatusCode }
+    HTTPError { status_code: StatusCode },
 }
 
 pub(crate) type Result<T> = std::result::Result<T, Error>;

--- a/src/message.rs
+++ b/src/message.rs
@@ -3,11 +3,11 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use crate::error::{Error, Result};
 use crate::structs::{ModifyOrderRequest, OrderRequest};
-use cached::proc_macro::cached;
 use cached::SizedCache;
+use cached::proc_macro::cached;
 use reqwest::header::{HeaderMap, HeaderValue};
-use rust_decimal::prelude::ToPrimitive;
 use rust_decimal::Decimal;
+use rust_decimal::prelude::ToPrimitive;
 use starknet_core::crypto::compute_hash_on_elements;
 use starknet_core::types::Felt;
 use starknet_core::utils::{
@@ -245,8 +245,7 @@ fn str_to_felt(s: &str) -> Result<Felt> {
     if s.chars().all(|c| c.is_ascii_digit()) {
         Ok(Felt::from_dec_str(s).map_err(|e| Error::StarknetError(e.to_string()))?)
     } else {
-        Ok(cairo_short_string_to_felt(s)
-            .map_err(|e| Error::StarknetError(e.to_string()))?)
+        Ok(cairo_short_string_to_felt(s).map_err(|e| Error::StarknetError(e.to_string()))?)
     }
 }
 
@@ -307,8 +306,8 @@ mod tests {
     use super::*;
 
     use crate::structs::{Order, OrderInstruction, OrderRequest, OrderType, Side};
-    use rust_decimal::prelude::FromPrimitive;
     use rust_decimal::Decimal;
+    use rust_decimal::prelude::FromPrimitive;
     use starknet_core::types::Felt;
     use starknet_signers::SigningKey;
 

--- a/src/message.rs
+++ b/src/message.rs
@@ -8,13 +8,13 @@ use cached::proc_macro::cached;
 use reqwest::header::{HeaderMap, HeaderValue};
 use rust_decimal::Decimal;
 use rust_decimal::prelude::ToPrimitive;
-use starknet_core::crypto::compute_hash_on_elements;
-use starknet_core::types::Felt;
-use starknet_core::utils::{
+use starknet::core::crypto::compute_hash_on_elements;
+use starknet::core::types::Felt;
+use starknet::core::utils::{
     cairo_short_string_to_felt, get_contract_address, get_selector_from_name, starknet_keccak,
 };
+use starknet::signers::SigningKey;
 use starknet_crypto::{PedersenHasher, Signature};
-use starknet_signers::SigningKey;
 
 /*
 Ideally we could just use logic similar to below for signing.
@@ -235,7 +235,7 @@ pub fn sign_order(
 }
 
 static MODIFY_ORDER_TYPE_HASH: std::sync::LazyLock<Felt> = std::sync::LazyLock::new(|| {
-    starknet_core::utils::starknet_keccak(
+    starknet::core::utils::starknet_keccak(
         "ModifyOrder(timestamp:felt,market:felt,side:felt,orderType:felt,size:felt,price:felt,id:felt)"
             .as_bytes(),
     )
@@ -308,8 +308,8 @@ mod tests {
     use crate::structs::{Order, OrderInstruction, OrderRequest, OrderType, Side};
     use rust_decimal::Decimal;
     use rust_decimal::prelude::FromPrimitive;
-    use starknet_core::types::Felt;
-    use starknet_signers::SigningKey;
+    use starknet::core::types::Felt;
+    use starknet::signers::SigningKey;
 
     #[test]
     fn test_domain_hash() {

--- a/src/rest.rs
+++ b/src/rest.rs
@@ -140,7 +140,10 @@ impl Client {
     /// If the markets cannot be retrieved
     pub async fn markets(&self, asset: Option<String>) -> Result<Vec<MarketSummaryStatic>> {
         let params = match asset {
-            Some(asset) => vec![("market".to_string(), format!("{}-USD-PERP", asset.to_ascii_uppercase()))],
+            Some(asset) => vec![(
+                "market".to_string(),
+                format!("{}-USD-PERP", asset.to_ascii_uppercase()),
+            )],
             None => vec![],
         };
         self.request(Method::Get::<()>(params), "/v1/markets".into(), None)

--- a/src/rest.rs
+++ b/src/rest.rs
@@ -138,8 +138,12 @@ impl Client {
     /// # Errors
     ///
     /// If the markets cannot be retrieved
-    pub async fn markets(&self) -> Result<Vec<MarketSummaryStatic>> {
-        self.request(Method::Get::<()>(vec![]), "/v1/markets".into(), None)
+    pub async fn markets(&self, asset: Option<String>) -> Result<Vec<MarketSummaryStatic>> {
+        let params = match asset {
+            Some(asset) => vec![("market".to_string(), format!("{}-USD-PERP", asset.to_ascii_uppercase()))],
+            None => vec![],
+        };
+        self.request(Method::Get::<()>(params), "/v1/markets".into(), None)
             .await
             .map(
                 |result_container: ResultsContainer<Vec<MarketSummaryStatic>>| {

--- a/src/rest.rs
+++ b/src/rest.rs
@@ -4,9 +4,9 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use log::trace;
 use reqwest::header::{HeaderMap, HeaderValue};
-use starknet_core::types::Felt;
-use starknet_core::utils::cairo_short_string_to_felt;
-use starknet_signers::SigningKey;
+use starknet::core::types::Felt;
+use starknet::core::utils::cairo_short_string_to_felt;
+use starknet::signers::SigningKey;
 use tokio::sync::RwLock;
 
 use crate::error::{Error, Result};

--- a/src/structs.rs
+++ b/src/structs.rs
@@ -647,6 +647,11 @@ pub struct Fill {
         deserialize_with = "deserialize_string_to_f64"
     )]
     pub remaining_size: f64,
+    #[serde(
+        serialize_with = "serialize_f64_as_string",
+        deserialize_with = "deserialize_string_to_f64"
+    )]
+    pub size: f64,
     //pub seq_no : u64, //in paradex documentation, but does not appear to be sent.
     pub fill_type: FillType,
     #[serde(

--- a/src/structs.rs
+++ b/src/structs.rs
@@ -767,6 +767,11 @@ pub struct AccountMarginUpdate {
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct AccountSlippageUpdate {
+    pub max_slippage: u64,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct AccountMarginUpdateResponse {
     pub account: String,
     pub leverage: u64,

--- a/src/structs.rs
+++ b/src/structs.rs
@@ -1,7 +1,7 @@
 use crate::error::{Error, Result};
 use rust_decimal::Decimal;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
-use starknet_core::utils::cairo_short_string_to_felt;
+use starknet::core::utils::cairo_short_string_to_felt;
 use starknet_crypto::Felt;
 use std::str::FromStr;
 

--- a/src/structs.rs
+++ b/src/structs.rs
@@ -768,7 +768,7 @@ pub struct AccountMarginUpdate {
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct AccountSlippageUpdate {
-    pub max_slippage: u64,
+    pub max_slippage: String,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]

--- a/src/ws.rs
+++ b/src/ws.rs
@@ -3,17 +3,17 @@ use crate::url::URL;
 use crate::{
     error::{self, Error, Result},
     rest::Client,
-    structs::{Fill, FundingData, MarketSummary, OrderBook, OrderUpdate, Trade, BBO},
+    structs::{BBO, Fill, FundingData, MarketSummary, OrderBook, OrderUpdate, Trade},
 };
-use futures_util::{stream::StreamExt, SinkExt};
+use futures_util::{SinkExt, stream::StreamExt};
 use jsonrpsee_core::{params::ObjectParams, traits::ToRpcParams};
 use jsonrpsee_types::{Notification, Response, ResponsePayload};
 use log::{info, trace, warn};
 use serde_json::Value;
 use std::{
     borrow::Cow,
-    collections::{hash_map::Entry, HashMap},
-    sync::{atomic::AtomicU64, Arc},
+    collections::{HashMap, hash_map::Entry},
+    sync::{Arc, atomic::AtomicU64},
     time::Duration,
 };
 use tokio::{
@@ -22,9 +22,8 @@ use tokio::{
     task::spawn,
 };
 use tokio_tungstenite::{
-    connect_async,
+    MaybeTlsStream, WebSocketStream, connect_async,
     tungstenite::{client::IntoClientRequest, http::Uri},
-    MaybeTlsStream, WebSocketStream,
 };
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -301,10 +300,7 @@ impl WebsocketManager {
                                     }
                                 }
                                 Err(e) => {
-                                    log::error!(
-                                        "Could not retrieve jwt auth token {}",
-                                        e
-                                    );
+                                    log::error!("Could not retrieve jwt auth token {}", e);
                                 }
                             }
                         }


### PR DESCRIPTION
## Summary

- Updates the Pragma cargo registry URL from **devnet** to **production** in `.cargo/config.toml`
- `registry.devnet.pragma.build` → `registry.production.pragma.build`

## Context

Migrating all repositories to use the production Pragma registry.